### PR TITLE
Darwin Benchmarks

### DIFF
--- a/darwin-amd64-e77430da3316.txt
+++ b/darwin-amd64-e77430da3316.txt
@@ -1,0 +1,53 @@
+# 2.4 GHz Core 2 Duo, 8 GB 1067 MHz DDR3
+# OSX 10.8.3 (Build 12D78)
+# MacBookPro7,1
+benchmark                         old ns/op    new ns/op    delta
+BenchmarkBinaryTree17            8835524000   9765677982  +10.53%
+BenchmarkFannkuch11              7952475000   5648760691  -28.97%
+BenchmarkFmtFprintfEmpty                227          186  -18.06%
+BenchmarkFmtFprintfString               753          481  -36.12%
+BenchmarkFmtFprintfInt                  495          329  -33.54%
+BenchmarkFmtFprintfIntInt               759          527  -30.57%
+BenchmarkFmtFprintfPrefixedInt          801          630  -21.35%
+BenchmarkFmtFprintfFloat               1155          812  -29.70%
+BenchmarkFmtManyArgs                   3190         2065  -35.27%
+BenchmarkGobDecode                 30132920     19873930  -34.05%
+BenchmarkGobEncode                 17536000     21087551  +20.25%
+BenchmarkGzip                     725107600    756534405   +4.33%
+BenchmarkGunzip                   297134800    173608372  -41.57%
+BenchmarkHTTPClientServer            196808       137551  -30.11%
+BenchmarkJSONEncode               110267700     74110819  -32.79%
+BenchmarkJSONDecode               420232200    160978374  -61.69%
+BenchmarkMandelbrot200             12249860      7419238  -39.43%
+BenchmarkGoParse                   11714580      9874640  -15.71%
+BenchmarkRegexpMatchEasy0_32            253          227  -10.28%
+BenchmarkRegexpMatchEasy0_1K            759          545  -28.19%
+BenchmarkRegexpMatchEasy1_32            228          194  -14.91%
+BenchmarkRegexpMatchEasy1_1K           1503         1499   -0.27%
+BenchmarkRegexpMatchMedium_32           370          325  -12.16%
+BenchmarkRegexpMatchMedium_1K        122935       121343   -1.29%
+BenchmarkRegexpMatchHard_32            5915         6187   +4.60%
+BenchmarkRegexpMatchHard_1K          180008       200218  +11.23%
+BenchmarkRevcomp                 1531299000   1393453776   -9.00%
+BenchmarkTemplate                 635606400    219187263  -65.52%
+BenchmarkTimeParse                     1934          793  -59.00%
+BenchmarkTimeFormat                    4015          846  -78.93%
+
+benchmark                          old MB/s     new MB/s  speedup
+BenchmarkGobDecode                    25.47        38.62    1.52x
+BenchmarkGobEncode                    43.77        36.40    0.83x
+BenchmarkGzip                         26.76        25.65    0.96x
+BenchmarkGunzip                       65.31       111.77    1.71x
+BenchmarkJSONEncode                   17.60        26.18    1.49x
+BenchmarkJSONDecode                    4.62        12.05    2.61x
+BenchmarkGoParse                       4.94         5.87    1.19x
+BenchmarkRegexpMatchEasy0_32         126.43       140.48    1.11x
+BenchmarkRegexpMatchEasy0_1K        1347.59      1876.83    1.39x
+BenchmarkRegexpMatchEasy1_32         139.98       164.60    1.18x
+BenchmarkRegexpMatchEasy1_1K         681.26       682.68    1.00x
+BenchmarkRegexpMatchMedium_32          2.70         3.07    1.14x
+BenchmarkRegexpMatchMedium_1K          8.33         8.44    1.01x
+BenchmarkRegexpMatchHard_32            5.41         5.17    0.96x
+BenchmarkRegexpMatchHard_1K            5.69         5.11    0.90x
+BenchmarkRevcomp                     165.98       182.40    1.10x
+BenchmarkTemplate                      3.05         8.85    2.90x


### PR DESCRIPTION
2.4 GHz Core 2 Duo, 8 GB 1067 MHz DDR3
OSX 10.8.3 (Build 12D78)
MacBookPro7,1

Great tool buddy, thanks for the work. I hope I appended the hash to the file in the correct manner.
