### PR TITLE
Add BenchmarkGoroutinesWaiting

### DIFF
--- a/src/bench/runtime/scheduler_test.go
+++ b/src/bench/runtime/scheduler_test.go
@@ -1,0 +1,27 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package runtime_test
+
+import (
+	"testing"
+)
+
+func BenchmarkGoroutinesWaiting(b *testing.B) {
+	benchmarkGoroutinesWaiting(b, 1000)
+}
+
+// benchmarkGoroutinesWaiting opens `simul` goroutines at once, all waiting on a
+// value from a single channel.
+func benchmarkGoroutinesWaiting(b *testing.B, simul int) {
+	c := make(chan bool)
+	f := func(c chan bool) { <-c }
+	for i := 0; i < b.N; i++ {
+		go f(c)
+		if (i+1)%simul == 0 {
+			c <- true
+		}
+	}
+	c <- true
+}


### PR DESCRIPTION
This benchmark tests the performance of the runtime when opening thousands of
goroutines simultaneously and leaving them waiting on a channel read. It seems
to expose a substantial performance regression in Go 1.1:

```
benchmark                                old ns/op    new ns/op    delta
BenchmarkGoroutinesWaiting                    3579       110215  +2979.49%
```

_I'll send a link to this to the mailing list._
