### PR TITLE
Removed spurious stoptimer

### DIFF
--- a/src/bench/floats/floats_test.go
+++ b/src/bench/floats/floats_test.go
@@ -131,7 +131,6 @@ func BenchmarkMinLarge(b *testing.B) {
 	benchmarkMin(b, s)
 }
 func BenchmarkMinHuge(b *testing.B) {
-	b.StopTimer()
 	s := RandomSlice(HUGE)
 	benchmarkMin(b, s)
 }


### PR DESCRIPTION
Forgot to remove a StopTimer() which causes the benchmark to fail. Sorry. 
